### PR TITLE
added NHS-R community workspace link.

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -88,7 +88,7 @@ Thanks to<br/>Stephan Kadauke
 # Links
 
 - Link to this website: [spcanelon.github.io/xaringan-basics-and-beyond](https://spcanelon.github.io/xaringan-basics-and-beyond/index.html)
-- [RStudio Cloud workspace (_coming soon!_)]()
+- [RStudio Cloud workspace (_coming soon!_)](https://bit.ly/3mfJM4k)
 - [Day 1 slides: The Basics (_coming soon!_)]()
 - [Day 2 slides: The Beyond (_coming soon!_)]()
 


### PR DESCRIPTION
Hi Silvia, thanks for contributing to NHS-R conference workshops.  I've added the link for the workspace in rstudio cloud.  All the other sessions have materials to share with attendees and, although we've got a link to the distill site, I've not got anything to load into the workspace.  Will you need materials adding or shall I set up a blank project for your session.  Already loaded xaringan, xaringanExtra and dependencies into the base project, but please let me know if there is anything else you need to save on install time during your sessions.